### PR TITLE
Adds the ability to disable rabbitmq heartbeats

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,6 +11,7 @@ default['rabbitmq']['config'] = nil
 default['rabbitmq']['logdir'] = nil
 default['rabbitmq']['mnesiadir'] = '/var/lib/rabbitmq/mnesia'
 default['rabbitmq']['service_name'] = 'rabbitmq-server'
+default['rabbitmq']['heartbeat'] = nil
 
 # config file location
 # http://www.rabbitmq.com/configure.html#define-environment-variables

--- a/templates/default/rabbitmq.config.erb
+++ b/templates/default/rabbitmq.config.erb
@@ -41,6 +41,9 @@
 <% if node['rabbitmq']['vm_memory_high_watermark'] -%>
     {vm_memory_high_watermark, <%= node['rabbitmq']['vm_memory_high_watermark'] %>},
 <% end %>
+<% unless node['rabbitmq']['heartbeat'].nil? -%>
+    {heartbeat, <%= node['rabbitmq']['heartbeat'] %>},
+<% end -%>
     {default_user, <<"<%= node['rabbitmq']['default_user'] %>">>},
     {default_pass, <<"<%= node['rabbitmq']['default_pass'] %>">>}
   ]}

--- a/test/cookbooks/rabbitmq_test/files/default/tests/minitest/disabled_heartbeats.rb
+++ b/test/cookbooks/rabbitmq_test/files/default/tests/minitest/disabled_heartbeats.rb
@@ -1,0 +1,61 @@
+#
+# Copyright 2012-2013, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require File.expand_path('../support/helpers', __FILE__)
+
+describe 'rabbitmq_test::disabled_heartbeats' do
+  include Helpers::RabbitMQ
+
+  # packages
+  it 'installs the rabbitmq-server package' do
+    if node['rabbitmq']['use_distro_version']
+      package('rabbitmq-server').must_be_installed
+    else
+      package('rabbitmq-server').must_be_installed.with(:version, '3.1.5-1')
+    end
+  end
+
+  # directories
+  it 'creates the mnesia directory' do
+    directory(node['rabbitmq']['mnesiadir']).must_have(:mode, '775').with(:owner, 'rabbitmq').and(:group, 'rabbitmq')
+  end
+
+  # file
+  it 'has the correct config files' do
+    file("#{node['rabbitmq']['config_root']}/rabbitmq-env.conf").must_exist.with(:owner, 'root').and(:group, 'root')
+    file("#{node['rabbitmq']['config_root']}/rabbitmq.config").must_exist.with(:owner, 'root').and(:group, 'root')
+    ::IO.read("#{node['rabbitmq']['config_root']}/rabbitmq.config").include?('{heartbeat, 0}')
+  end
+
+  # service
+  it 'enables & starts the rabbitmq-server service' do
+    service(node['rabbitmq']['service_name']).must_be_enabled unless node['rabbitmq']['job_control'] == 'upstart'
+    service(node['rabbitmq']['service_name']).must_be_running unless node['rabbitmq']['use_distro_version']
+  end
+
+  # accepts connections
+  it 'accepts AMQP connections' do
+    unless node['rabbitmq']['use_distro_version']
+      require 'bunny'
+      b = Bunny.new(:host => 'localhost',
+                    :port => 5672,
+                    :user => node['rabbitmq']['default_user'],
+                    :pass => node['rabbitmq']['default_pass'])
+      b.start
+      b.stop
+    end
+  end
+end

--- a/test/cookbooks/rabbitmq_test/recipes/disabled_heartbeats.rb
+++ b/test/cookbooks/rabbitmq_test/recipes/disabled_heartbeats.rb
@@ -1,0 +1,15 @@
+#
+# Cookbook Name:: rabbitmq_test
+# Recipe:: cook-2151-3489
+#
+# This recipe exists to ensure that minitest tests are run.
+
+node.default['rabbitmq']['heartbeat'] = 0
+include_recipe 'rabbitmq::default'
+
+# HACK: Give rabbit time to spin up before the tests, it seems
+# to be responding that it has started before it really has
+execute 'sleep 10' do
+  action :nothing
+  subscribes :run, "service[#{node['rabbitmq']['service_name']}]", :delayed
+end


### PR DESCRIPTION
One of our client libraries doesn't support heartbeats, so we have to disable them on certain servers.