### PR TITLE
fixed a problem that rpm command returned exit code 2 when update was not needed

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -101,7 +101,11 @@ when 'rhel', 'fedora'
       source rpm_package
       action :create_if_missing
     end
-    rpm_package "#{Chef::Config[:file_cache_path]}/rabbitmq-server-#{node['rabbitmq']['version']}-1.noarch.rpm"
+    rpm_package "#{Chef::Config[:file_cache_path]}/rabbitmq-server-#{node['rabbitmq']['version']}-1.noarch.rpm" do
+      only_if do
+        `rpm -qa | grep '^rabbitmq-server-#{node['rabbitmq']['version']}-1' | wc -l`.strip == "0"
+      end
+    end
   end
 
   service node['rabbitmq']['service_name'] do


### PR DESCRIPTION
On CentOS 6.5, I got the following error:

```
$ sudo cat /var/chef/cache/chef-stacktrace.out
Generated at 2014-07-23 14:54:45 +0900
Chef::Exceptions::Exec: rpm_package[/var/chef/cache/rabbitmq-server-3.1.5-1.noarch.rpm] (rabbitmq::default line 115) had an error: Chef::Exceptions::Exec: rpm 
 -U /var/chef/cache/rabbitmq-server-3.1.5-1.noarch.rpm returned 2, expected 0
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.4/lib/chef/mixin/command.rb:158:in `handle_command_failures'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.4/lib/chef/mixin/command.rb:104:in `run_command_and_return_stdout_stderr'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.4/lib/chef/mixin/command.rb:79:in `run_command'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.4/lib/chef/mixin/command.rb:171:in `run_command_with_systems_locale'
```

As the message says, the following command returns exit code 2:

```
$ sudo rpm -U /var/chef/cache/rabbitmq-server-3.1.5-1.noarch.rpm
warning: /var/chef/cache/rabbitmq-server-3.1.5-1.noarch.rpm: Header V4 DSA/SHA1 Signature, key ID 056e8e56: NOKEY
        package rabbitmq-server-3.1.5-1.el6.noarch (which is newer than rabbitmq-server-3.1.5-1.noarch) is already installed
```

I changed the resource so as not to be executed when the same version existed.