### PR TITLE
Fix user_has_tag? issue when name and tag are the same

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -172,7 +172,7 @@ else
 end
 
 if node['rabbitmq']['cluster'] && (node['rabbitmq']['erlang_cookie'] != existing_erlang_key)
-  log "stop #{node['rabbitmq']['serice_name']} to change erlang cookie" do
+  log "stop #{node['rabbitmq']['service_name']} to change erlang cookie" do
     notifies :stop, "service[#{node['rabbitmq']['service_name']}]", :immediately
   end
 


### PR DESCRIPTION
When passing a user with name "management" and tag "management", the tag won't be created because in `user_has_tag?` method the tag is considered to be existed. I think it'd be easier only run `rabbitmqctl -q list_user management` as command, and parse the result with ruby regex function like:

    cmd.run_command
    user_list = cmd.stdout # => "management\t[management test]"
    tags = user_list.match(/^#{name}\s+\[(.+*)\]/)[1].split # => ["management", "test"]
