### PR TITLE
Add node['rabbitmq']['conf'] to the rabbit section

### DIFF
--- a/templates/default/rabbitmq.config.erb
+++ b/templates/default/rabbitmq.config.erb
@@ -48,8 +48,8 @@
     {default_user, <<"<%= node['rabbitmq']['default_user'] %>">>},
     {default_pass, <<"<%= node['rabbitmq']['default_pass'] %>">>},
     {heartbeat, <%= node['rabbitmq']['heartbeat'] %>}
-  ]}
 <% node['rabbitmq']['conf'].each do |key,value|  -%>
-	,{<%= key %>, <%= value %>}
+    ,{<%= key %>, <%= value %>}
 <% end -%>
+  ]}
 ].


### PR DESCRIPTION
This allows me to add ssl_allow_poodle_attack to the rabbit section of the config file (required with a too-old erlang).