### PR TITLE
Add ability to set loopback_users (only localhost access)

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -78,6 +78,7 @@ default['rabbitmq']['enabled_users'] =
     [{ :vhost => nil, :conf => '.*', :write => '.*', :read => '.*' }]
   }]
 default['rabbitmq']['disabled_users'] = []
+default['rabbitmq']['loopback_users'] = nil
 
 # plugins
 default['rabbitmq']['enabled_plugins'] = []

--- a/templates/default/rabbitmq.config.erb
+++ b/templates/default/rabbitmq.config.erb
@@ -47,6 +47,9 @@
 <% end %>
     {default_user, <<"<%= node['rabbitmq']['default_user'] %>">>},
     {default_pass, <<"<%= node['rabbitmq']['default_pass'] %>">>},
+<% if node['rabbitmq']['loopback_users'] -%>
+    {loopback_users, [<%= node['rabbitmq']['loopback_users'] %>]},
+<% end %>
     {heartbeat, <%= node['rabbitmq']['heartbeat'] %>}
   ]}
 <% node['rabbitmq']['conf'].each do |key,value|  -%>

--- a/test/cookbooks/rabbitmq_test/files/default/tests/minitest/cook-2151-3489_test.rb
+++ b/test/cookbooks/rabbitmq_test/files/default/tests/minitest/cook-2151-3489_test.rb
@@ -33,4 +33,9 @@ describe 'rabbitmq_test::cook-2151' do
     file("#{node['rabbitmq']['config_root']}/rabbitmq-env.conf")
       .must_match(/(ulimit -n #{node['rabbitmq']['open_file_limit']})/)
   end
+  
+  it 'includes the loopback_users configuration setting' do
+    file("#{node['rabbitmq']['config_root']}/rabbitmq.config")
+      .must_match(/\{loopback_users, \[#{node['rabbitmq']['loopback_users']}\]/)
+  end
 end

--- a/test/cookbooks/rabbitmq_test/recipes/cook-2151-3489.rb
+++ b/test/cookbooks/rabbitmq_test/recipes/cook-2151-3489.rb
@@ -5,6 +5,7 @@
 # This recipe exists to ensure that minitest tests are run.
 
 include_recipe 'rabbitmq::default'
+node.set['rabbitmq']['loopback_users'] = '<<"testuser">>'
 
 # HACK: Give rabbit time to spin up before the tests, it seems
 # to be responding that it has started before it really has


### PR DESCRIPTION
Please give me feedback :)

I was unsure if this is something which should be set through the user lwrp but it
is not really handy to test it. (The rabbitmqctl has no command to verify the
loopback_users) - So I decided to make it this way.

Greetings Thomas