### PR TITLE
Distro version pinning

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,6 +2,9 @@
 default['rabbitmq']['version'] = '3.4.3'
 # The distro versions may be more stable and have back-ported patches
 default['rabbitmq']['use_distro_version'] = false
+# Allow the distro version to be optionally pinned like the rabbitmq.com version
+default['rabbitmq']['pin_distro_version'] = false
+
 
 # being nil, the rabbitmq defaults will be used
 default['rabbitmq']['nodename']  = nil

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -35,7 +35,7 @@ when 'debian'
   if node['rabbitmq']['use_distro_version']
     package 'rabbitmq-server' do
       action :install
-      version node['rabbitmq']['version']
+      version node['rabbitmq']['version'] if node['rabbitmq']['pin_distro_version']
     end
   else
     # we need to download the package


### PR DESCRIPTION
Allow the distro version to be optionally pinned.  By default the available distro repo package will be used.