### PR TITLE
addition of attributes for downloading deb, rpm and esl-erlang-compat

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,6 +5,11 @@ default['rabbitmq']['use_distro_version'] = false
 # Allow the distro version to be optionally pinned like the rabbitmq.com version
 default['rabbitmq']['pin_distro_version'] = false
 
+# provide options to override download urls
+default['rabbitmq']['deb_package_url'] = 'https://www.rabbitmq.com/releases/rabbitmq-server/'
+default['rabbitmq']['rpm_package_url'] = 'https://www.rabbitmq.com/releases/rabbitmq-server/'
+default['rabbitmq']['esl-erlang_package_url'] = 'https://github.com/jasonmcintosh/esl-erlang-compat/blob/master/rpmbuild/RPMS/noarch/esl-erlang-compat-R14B-1.el6.noarch.rpm?raw=true'
+
 # being nil, the rabbitmq defaults will be used
 default['rabbitmq']['nodename']  = nil
 default['rabbitmq']['address']  = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,10 +5,15 @@ default['rabbitmq']['use_distro_version'] = false
 # Allow the distro version to be optionally pinned like the rabbitmq.com version
 default['rabbitmq']['pin_distro_version'] = false
 
-# provide options to override download urls
-default['rabbitmq']['deb_package_url'] = 'https://www.rabbitmq.com/releases/rabbitmq-server/'
-default['rabbitmq']['rpm_package_url'] = 'https://www.rabbitmq.com/releases/rabbitmq-server/'
-default['rabbitmq']['esl-erlang_package_url'] = 'https://github.com/jasonmcintosh/esl-erlang-compat/blob/master/rpmbuild/RPMS/noarch/esl-erlang-compat-R14B-1.el6.noarch.rpm?raw=true'
+# provide options to override download urls and package names
+default['rabbitmq']['deb_package'] = "rabbitmq-server_#{node['rabbitmq']['version']}-1_all.deb"
+default['rabbitmq']['deb_package_url'] = "https://www.rabbitmq.com/releases/rabbitmq-server/v#{node['rabbitmq']['version']}/"
+
+default['rabbitmq']['rpm_package'] = "rabbitmq-server-#{node['rabbitmq']['version']}-1.noarch.rpm"
+default['rabbitmq']['rpm_package_url'] = "https://www.rabbitmq.com/releases/rabbitmq-server/v#{node['rabbitmq']['version']}/"
+
+default['rabbitmq']['esl-erlang_package'] = 'esl-erlang-compat-R14B-1.el6.noarch.rpm?raw=true'
+default['rabbitmq']['esl-erlang_package_url'] = 'https://github.com/jasonmcintosh/esl-erlang-compat/blob/master/rpmbuild/RPMS/noarch/'
 
 # being nil, the rabbitmq defaults will be used
 default['rabbitmq']['nodename']  = nil

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -47,7 +47,7 @@ when 'debian'
     end
   else
     # we need to download the package
-    deb_package = "https://www.rabbitmq.com/releases/rabbitmq-server/v#{node['rabbitmq']['version']}/rabbitmq-server_#{node['rabbitmq']['version']}-1_all.deb"
+    deb_package = "#{node['rabbitmq']['deb_package_url']}v#{node['rabbitmq']['version']}/rabbitmq-server_#{node['rabbitmq']['version']}-1_all.deb"
     remote_file "#{Chef::Config[:file_cache_path]}/rabbitmq-server_#{node['rabbitmq']['version']}-1_all.deb" do
       source deb_package
       action :create_if_missing
@@ -99,7 +99,7 @@ when 'rhel', 'fedora'
   # This is needed since Erlang Solutions' packages provide "esl-erlang"; this package just requires "esl-erlang" and provides "erlang".
   if node['erlang']['install_method'] == 'esl'
     remote_file "#{Chef::Config[:file_cache_path]}/esl-erlang-compat.rpm" do
-      source 'https://github.com/jasonmcintosh/esl-erlang-compat/blob/master/rpmbuild/RPMS/noarch/esl-erlang-compat-R14B-1.el6.noarch.rpm?raw=true'
+      source node['rabbitmq']['esl-erlang_package_url']
     end
     rpm_package "#{Chef::Config[:file_cache_path]}/esl-erlang-compat.rpm"
   end
@@ -111,7 +111,7 @@ when 'rhel', 'fedora'
     end
   else
     # We need to download the rpm
-    rpm_package = "https://www.rabbitmq.com/releases/rabbitmq-server/v#{node['rabbitmq']['version']}/rabbitmq-server-#{node['rabbitmq']['version']}-1.noarch.rpm"
+    rpm_package = "#{node['rabbitmq']['rpm_package_url']}v#{node['rabbitmq']['version']}/rabbitmq-server-#{node['rabbitmq']['version']}-1.noarch.rpm"
 
     remote_file "#{Chef::Config[:file_cache_path]}/rabbitmq-server-#{node['rabbitmq']['version']}-1.noarch.rpm" do
       source rpm_package

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -47,12 +47,12 @@ when 'debian'
     end
   else
     # we need to download the package
-    deb_package = "#{node['rabbitmq']['deb_package_url']}v#{node['rabbitmq']['version']}/rabbitmq-server_#{node['rabbitmq']['version']}-1_all.deb"
-    remote_file "#{Chef::Config[:file_cache_path]}/rabbitmq-server_#{node['rabbitmq']['version']}-1_all.deb" do
+    deb_package = "#{node['rabbitmq']['deb_package_url']}#{node['rabbitmq']['deb_package']}"
+    remote_file "#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['deb_package']}" do
       source deb_package
       action :create_if_missing
     end
-    dpkg_package "#{Chef::Config[:file_cache_path]}/rabbitmq-server_#{node['rabbitmq']['version']}-1_all.deb" do
+    dpkg_package "#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['deb_package']}" do
       action :install
     end
   end
@@ -99,7 +99,7 @@ when 'rhel', 'fedora'
   # This is needed since Erlang Solutions' packages provide "esl-erlang"; this package just requires "esl-erlang" and provides "erlang".
   if node['erlang']['install_method'] == 'esl'
     remote_file "#{Chef::Config[:file_cache_path]}/esl-erlang-compat.rpm" do
-      source node['rabbitmq']['esl-erlang_package_url']
+      source "#{node['rabbitmq']['esl-erlang_package_url']}#{node['rabbitmq']['esl-erlang_package']}"
     end
     rpm_package "#{Chef::Config[:file_cache_path]}/esl-erlang-compat.rpm"
   end
@@ -111,13 +111,13 @@ when 'rhel', 'fedora'
     end
   else
     # We need to download the rpm
-    rpm_package = "#{node['rabbitmq']['rpm_package_url']}v#{node['rabbitmq']['version']}/rabbitmq-server-#{node['rabbitmq']['version']}-1.noarch.rpm"
+    rpm_package = "#{node['rabbitmq']['rpm_package_url']}#{node['rabbitmq']['rpm_package']}"
 
-    remote_file "#{Chef::Config[:file_cache_path]}/rabbitmq-server-#{node['rabbitmq']['version']}-1.noarch.rpm" do
+    remote_file "#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['rpm_package']}" do
       source rpm_package
       action :create_if_missing
     end
-    rpm_package "#{Chef::Config[:file_cache_path]}/rabbitmq-server-#{node['rabbitmq']['version']}-1.noarch.rpm"
+    rpm_package "#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['rpm_package']}"
   end
 
 when 'suse'


### PR DESCRIPTION
added attributes that allow configuration of the download url and package name for rabbitmq deb and rpm and esl-erlang-compat rpm, for example for those that do not have the luxury to connect production environments to the outside world.