### PR TITLE
Change module back to Opscode.

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-module Chef
+module Opscode
   # module rabbit
   module RabbitMQ
     # This method does some of the yuckiness of formatting parameters properly

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,7 +21,7 @@
 
 #
 class Chef::Resource # rubocop:disable all
-  include Chef::RabbitMQ # rubocop:enable all
+  include Opscode::RabbitMQ # rubocop:enable all
 end
 
 case node['platform_family']


### PR DESCRIPTION
The module needs to remain Opscode or some other type of clever
Chef-named derivative.