### PR TITLE
Remove yum-epel case statement.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,14 +24,6 @@ class Chef::Resource # rubocop:disable all
   include Opscode::RabbitMQ # rubocop:enable all
 end
 
-case node['platform_family']
-when  'rhel', 'fedora'
-  if node['platform_version'].to_f >= 7.0
-    include_recipe 'yum-epel'
-    include_recipe 'yum-erlang_solutions'
-  end
-end
-
 include_recipe 'erlang'
 
 ## Install the package


### PR DESCRIPTION
As of [PR25](https://github.com/opscode-cookbooks/erlang/pull/25),
yum-epel and yum-erlang_solutions are included by
default for all 'rhel' systems greater than 5.

Tests will fail for this branch until a new release of the Erlang cookbook. I tested
with my Berksfile pointed at master and all was good.