### PR TITLE
Fix plugin_enabled not having path appended

### DIFF
--- a/providers/plugin.rb
+++ b/providers/plugin.rb
@@ -18,6 +18,7 @@
 #
 
 def plugin_enabled?(name)
+  ENV['PATH'] = "#{ENV['PATH']}:/usr/lib/rabbitmq/bin"
   cmdstr = "rabbitmq-plugins list -e '#{name}\\b'"
   cmd = Mixlib::ShellOut.new(cmdstr)
   cmd.environment['HOME'] = ENV.fetch('HOME', '/root')


### PR DESCRIPTION
Fix the problem of trying to check for existing plugins but rabbitmq-plugins is not on path yet.

On install and uninstall the path is added but not on checking if the plugin is enabled so on ubuntu12.04 it will fail.