### PR TITLE
Change select to each on line 230 for action change_cluster_node_type.

### DIFF
--- a/providers/cluster.rb
+++ b/providers/cluster.rb
@@ -227,7 +227,7 @@ action :change_cluster_node_type do
   var_cluster_status = cluster_status
   var_node_name = node_name
   var_current_cluster_node_type = current_cluster_node_type(var_node_name, var_cluster_status)
-  var_cluster_node_type = parse_cluster_nodes_string(new_resource.cluster_nodes).select { |node| node['name'] == var_node_name }.first['type'] # ~FC039
+  var_cluster_node_type = parse_cluster_nodes_string(new_resource.cluster_nodes).each { |node| node['name'] == var_node_name }.first['type'] # ~FC039
 
   if var_current_cluster_node_type == var_cluster_node_type
     Chef::Log.warn('[rabbitmq_cluster] Skip changing cluster node type : trying to change to same cluster node type')


### PR DESCRIPTION
This is a bug fix and not a feature.
This action would fail each time it tried to change the cluster type. Once I changed it to each, it now performed the task correctly