### PR TITLE
Support additional env args

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -116,3 +116,9 @@ attribute 'rabbitmq/loopback_users',
   :description => 'A list of users which can only connect over a loopback interface (localhost)',
   :default => nil,
   :type => 'array'
+
+attribute 'rabbitmq/additional_env_settings',
+  :display_name => 'Additional ENV settings',
+  :description => 'A list of lines to append to rabbitmq-env.conf for settings that may not yet be available with existing attributes',
+  :default => nil,
+  :type => 'array'

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -42,6 +42,21 @@ describe 'rabbitmq::default' do
         expect(chef_run).to render_file(file.name).with_content(line)
       end
     end
+
+    it 'has no additional_env_settings default' do
+      expect(chef_run).not_to render_file(file.name).with_content(/^# Additional ENV settings/)
+    end
+
+    it 'has additional_env_settings' do
+      node.set['rabbitmq']['additional_env_settings'] = [
+        'USE_LONGNAME=true',
+        'WHATS_ON_THE_TELLY=penguin']
+      [/^WHATS_ON_THE_TELLY=penguin/,
+       /^# Additional ENV settings/,
+       /^USE_LONGNAME=true/].each do |line|
+        expect(chef_run).to render_file(file.name).with_content(line)
+      end
+    end
   end
 
   it 'should create the directory /var/lib/rabbitmq/mnesia' do
@@ -88,21 +103,21 @@ describe 'rabbitmq::default' do
   describe 'ssl ciphers' do
     it 'has no ssl ciphers specified by default' do
       expect(chef_run).not_to render_file('/etc/rabbitmq/rabbitmq.config').with_content(
-                                /{ciphers,[{.*}]}/)
+        /{ciphers,[{.*}]}/)
     end
 
     it 'allows ssl ciphers' do
       node.set['rabbitmq']['ssl'] = true
       node.set['rabbitmq']['ssl_ciphers'] = ['ecdhe_ecdsa,aes_128_cbc,sha256', 'ecdhe_ecdsa,aes_256_cbc,sha']
       expect(chef_run).to render_file('/etc/rabbitmq/rabbitmq.config').with_content(
-                            '{ciphers,[{ecdhe_ecdsa,aes_128_cbc,sha256},{ecdhe_ecdsa,aes_256_cbc,sha}]}')
+        '{ciphers,[{ecdhe_ecdsa,aes_128_cbc,sha256},{ecdhe_ecdsa,aes_256_cbc,sha}]}')
     end
 
     it 'allows web console ssl ciphers' do
       node.set['rabbitmq']['web_console_ssl'] = true
       node.set['rabbitmq']['ssl_ciphers'] = ['ecdhe_ecdsa,aes_128_cbc,sha256', 'ecdhe_ecdsa,aes_256_cbc,sha']
       expect(chef_run).to render_file('/etc/rabbitmq/rabbitmq.config').with_content(
-                            '{ciphers,[{ecdhe_ecdsa,aes_128_cbc,sha256},{ecdhe_ecdsa,aes_256_cbc,sha}]}')
+        '{ciphers,[{ecdhe_ecdsa,aes_128_cbc,sha256},{ecdhe_ecdsa,aes_256_cbc,sha}]}')
     end
 
     it 'should set additional rabbitmq config' do
@@ -159,10 +174,10 @@ describe 'rabbitmq::default' do
 
     it 'creates a template rabbitmq-server with attributes' do
       expect(chef_run).to create_template('/etc/default/rabbitmq-server').with(
-                            :user => 'root',
-                            :group => 'root',
-                            :source => 'default.rabbitmq-server.erb',
-                            :mode => 00644)
+        :user => 'root',
+        :group => 'root',
+        :source => 'default.rabbitmq-server.erb',
+        :mode => 00644)
     end
 
     it 'should undo the service disable hack' do

--- a/templates/default/rabbitmq-env.conf.erb
+++ b/templates/default/rabbitmq-env.conf.erb
@@ -21,3 +21,9 @@ export ERL_EPMD_ADDRESS=<%= node['rabbitmq']['erl_networking_bind_address'] %>
 <% if node['rabbitmq']['open_file_limit'] -%>ulimit -n <%= node['rabbitmq']['open_file_limit'] %><% end %>
 <% if node['rabbitmq']['server_additional_erl_args'] -%>SERVER_ADDITIONAL_ERL_ARGS='<%= node['rabbitmq']['server_additional_erl_args'] %>'<% end %>
 <% if node['rabbitmq']['ctl_erl_args'] -%>CTL_ERL_ARGS='<%= node['rabbitmq']['ctl_erl_args'] %>'<% end %>
+<% if node['rabbitmq']['additional_env_settings'] -%>
+# Additional ENV settings
+<% node['rabbitmq']['additional_env_settings'].each do |line| -%>
+<%= line %>
+<% end -%>
+<% end -%>


### PR DESCRIPTION
If attribute node['node']['additional_env_settings'] exists, it is
expected to be an array of strings, which will then be appended
to rabbit-env.conf. This allows users the flexibility to specify
ENV settings that don't have explicit attributes. (E.g. Some
settings may be new to rabbitmq but won't require a recipe update
before people can take advantage of them.)

I also cleaned up a couple of rubocop issues in default_spec.rb