### PR TITLE
Fixed 'rabbitmqctl eval' command for old rabbitmq versions

### DIFF
--- a/providers/cluster.rb
+++ b/providers/cluster.rb
@@ -103,7 +103,7 @@ end
 # Get node name
 def node_name
   # execute > rabbitmqctl eval 'node().'
-  cmd = 'rabbitmqctl eval "node()."'
+  cmd = 'rabbitmqctl eval "node()." | head -1'
   Chef::Log.debug("[rabbitmq_cluster] Executing #{cmd}")
   cmd = get_shellout(cmd)
   cmd.run_command


### PR DESCRIPTION
This is a known issue in rabbitmq 3.3.4 or earlier, and the `rabbitmqctl` commands always appends `...done.` at the end of outputs, which causes issues in `cluster.rb` when doing join to the cluster.
Please refer to my issue for details: https://github.com/jjasghar/rabbitmq/issues/271

This fix force the command `rabbitmqctl eval "node()."` to always print out the first line which filters out the wrong tail string.

Before
```
[root@prod-rabbitmq-1001 ~]# rabbitmqctl eval "node()."
'rabbit@prod-rabbitmq-1001'
...done.
```

After
```
[root@prod-rabbitmq-1001 ~]# rabbitmqctl eval "node()." | head -1
'rabbit@prod-rabbitmq-1001'
```

I've tested this PR in the latest rabbitmq 3.5.3 and old versions like 3.3.4 and 3.2.3, and everything looks fine.

Thanks!