### PR TITLE
Fix cluster provider which fails when no ram nodes listed in cluster_status.

### DIFF
--- a/providers/cluster.rb
+++ b/providers/cluster.rb
@@ -60,12 +60,12 @@ def cluster_status
 end
 
 # Match regex pattern from result of rabbitmqctl cluster_status
+# When no match (eg. matching ram nodes when none listed), returns empty string
 def match_pattern_cluster_status(cluster_status, pattern)
   if cluster_status.nil? || cluster_status.to_s.empty?
     Chef::Application.fatal!('[rabbitmq_cluster] cluster_status should not be empty')
   end
-  match = cluster_status.match(pattern)
-  match[2]
+  cluster_status.match(pattern) { |match| match[2] } || ''
 end
 
 # Get currently joined cluster name from result string of "rabbitmqctl cluster_status"


### PR DESCRIPTION
This PR fixes the cluster provider which failed when the output of `rabbitmqctl cluster_status` did not match the regexp passed to the `match_pattern_cluster_status` private method (in my case information about the ram nodes in the cluster).

To give an example, the `ram_nodes` private method would raise with the following `rabbitmqctl cluster_status` output because it looked for ram node information which is not present in my version of rabbitmq when I declare no such nodes.

```
[{nodes,[{disc,['rabbit@backends-vm','rabbit@failover-1-vm']}]},
 {running_nodes,['rabbit@failover-1-vm','rabbit@backends-vm']},
 {cluster_name,<<"dev">>},
 {partitions,[]}]
```

This PR make the `match_pattern_cluster_status` method return an empty string when the cluster_status does not match the provided regexp.