### PR TITLE
Fix single quote and nil issues with cluster recipe

### DIFF
--- a/providers/cluster.rb
+++ b/providers/cluster.rb
@@ -78,7 +78,7 @@ end
 
 # Get running nodes
 def running_nodes(cluster_status)
-  pattern = '({running_nodes,\[)(.*?)(\]})'
+  pattern = '({running_nodes,\[\'*)(.*?)(\'*\]})'
   result = match_pattern_cluster_status(cluster_status, pattern)
   Chef::Log.debug("[rabbitmq_cluster] running_nodes : #{result}")
   result.split(',')
@@ -86,7 +86,7 @@ end
 
 # Get disc nodes
 def disc_nodes(cluster_status)
-  pattern = '({disc,\[)(.*?)(\]})'
+  pattern = '({disc,\[\'*)(.*?)(\'*\]})'
   result = match_pattern_cluster_status(cluster_status, pattern)
   Chef::Log.debug("[rabbitmq_cluster] disc_nodes : #{result}")
   result.split(',')
@@ -94,7 +94,7 @@ end
 
 # Get ram nodes
 def ram_nodes(cluster_status)
-  pattern = '({ram,\[)(.*?)(\]})'
+  pattern = '({ram,\[\'*)(.*?)(\'*\]})'
   result = match_pattern_cluster_status(cluster_status, pattern)
   Chef::Log.debug("[rabbitmq_cluster] ram_nodes : #{result}")
   result.split(',')
@@ -109,6 +109,7 @@ def node_name
   cmd.run_command
   cmd.error!
   result = cmd.stdout.chomp
+  result.gsub!(/'/, '')
   Chef::Log.debug("[rabbitmq_cluster] node name : #{result}")
   result
 end

--- a/providers/cluster.rb
+++ b/providers/cluster.rb
@@ -82,24 +82,25 @@ def running_nodes(cluster_status)
   match = match_pattern_cluster_status(cluster_status, pattern)
   result = match && match.gsub!(/'/, '').split(',')
   Chef::Log.debug("[rabbitmq_cluster] running_nodes : #{result}")
+  !result.nil? ? result.split(',') : []
 end
 
 # Get disc nodes
 def disc_nodes(cluster_status)
   pattern = '({disc,\[\'*)(.*?)(\'*\]})'
   match = match_pattern_cluster_status(cluster_status, pattern)
-  result = match && match.gsub!(/'/, '').split(',')
+  result = match && match.gsub!(/'/, '')
   Chef::Log.debug("[rabbitmq_cluster] disc_nodes : #{result}")
-  !result.nil? ? result : []
+  !result.nil? ? result.split(',') : []
 end
 
 # Get ram nodes
 def ram_nodes(cluster_status)
   pattern = '({ram,\[\'*)(.*?)(\'*\]})'
   match = match_pattern_cluster_status(cluster_status, pattern)
-  result = match && match.gsub!(/'/, '').split(',')
+  result = match && match.gsub!(/'/, '')
   Chef::Log.debug("[rabbitmq_cluster] ram_nodes : #{result}")
-  !result.nil? ? result : []
+  !result.nil? ? result.split(',') : []
 end
 
 # Get node name

--- a/providers/cluster.rb
+++ b/providers/cluster.rb
@@ -80,9 +80,10 @@ end
 # Get running nodes
 def running_nodes(cluster_status)
   pattern = '({running_nodes,\[\'*)(.*?)(\'*\]})'
-  result = match_pattern_cluster_status(cluster_status, pattern)
+  match = match_pattern_cluster_status(cluster_status, pattern)
+  result = match && match.split(',')
   Chef::Log.debug("[rabbitmq_cluster] running_nodes : #{result}")
-  result.split(',')
+  result
 end
 
 # Get disc nodes
@@ -133,7 +134,7 @@ end
 
 # Checking node is joined in cluster
 def joined_cluster?(node_name, cluster_status)
-  running_nodes(cluster_status).include?(node_name)
+  (running_nodes(cluster_status) || '').include?(node_name)
 end
 
 # Join cluster.


### PR DESCRIPTION
This builds on #267 to add:

- More fixes to catch single quotes from cluster_status, current_cluster_node_type and node_name
  - Fixes from #267 the node_name still had single quotes which were removed on L113
  - The cluster_status, disc_nodes and ram_nodes functions passed back a match of ["rabbit@rabbit1'","'rabbit@rabbit2"] which contained single quotes from the middle of the match. This was removed L83, L91 and L100

In rare instances, if the cluster_status returns on a non running server or is not clustered yet, the matchers caused no matched and nil errors. Fixes were introduced to pass nil in some functions through and to better handle them specifically with cluster_join:

- Passthrough of nil in some functions
- Additional debug logging and handling of nil responses from functions