### PR TITLE
Allow for flexiable SSL cipher formats

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -44,7 +44,7 @@ module Opscode
     end
 
     def format_ssl_ciphers
-      Array(node['rabbitmq']['ssl_ciphers']).map { |n| "'#{n}'" }.join(',')
+      Array(node['rabbitmq']['ssl_ciphers']).join(',')
     end
   end
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -108,16 +108,16 @@ describe 'rabbitmq::default' do
 
     it 'allows ssl ciphers' do
       node.set['rabbitmq']['ssl'] = true
-      node.set['rabbitmq']['ssl_ciphers'] = ['ecdhe_ecdsa,aes_128_cbc,sha256', 'ecdhe_ecdsa,aes_256_cbc,sha']
+      node.set['rabbitmq']['ssl_ciphers'] = ['{ecdhe_ecdsa,aes_128_cbc,sha256}', '{ecdhe_ecdsa,aes_256_cbc,sha}']
       expect(chef_run).to render_file('/etc/rabbitmq/rabbitmq.config').with_content(
-                            "{ciphers,['ecdhe_ecdsa,aes_128_cbc,sha256','ecdhe_ecdsa,aes_256_cbc,sha']}")
+                            '{ciphers,[{ecdhe_ecdsa,aes_128_cbc,sha256},{ecdhe_ecdsa,aes_256_cbc,sha}]}')
     end
 
     it 'allows web console ssl ciphers' do
       node.set['rabbitmq']['web_console_ssl'] = true
-      node.set['rabbitmq']['ssl_ciphers'] = ['ecdhe_ecdsa,aes_128_cbc,sha256', 'ecdhe_ecdsa,aes_256_cbc,sha']
+      node.set['rabbitmq']['ssl_ciphers'] = ['"ECDHE-ECDSA-AES256-SHA384"', '"ECDH-ECDSA-AES256-SHA384"']
       expect(chef_run).to render_file('/etc/rabbitmq/rabbitmq.config').with_content(
-                            "{ciphers,['ecdhe_ecdsa,aes_128_cbc,sha256','ecdhe_ecdsa,aes_256_cbc,sha']}")
+                            "{ciphers,[\"ECDHE-ECDSA-AES256-SHA384\",\"ECDH-ECDSA-AES256-SHA384\"]}")
     end
 
     it 'should set additional rabbitmq config' do


### PR DESCRIPTION
Current cookbook (my bad) forced the ssl cipher format to be enclosed with single quotes. This turns out to be almost a completely invalid way of specifying ssl ciphers.  This patch removes those quotes and leaves it up to the user to specify ssl ciphers in any of the various formats, like those used in the spec and shown below.

Using erlang style cipher suite configuration, (see output of command rabbitmqctl eval 'ssl:cipher_suites(erlang)', which is lower cases with {}:

node['rabbitmq']['ssl_ciphers'] = %w({ecdhe_ecdsa,aes_256_cbc,sha384} {ecdh_ecdsa,aes_256_cbc,sha384})

Using UPPERCASE cipher constants:

node['rabbitmq']['ssl_ciphers'] = %w("ECDHE-ECDSA-AES256-SHA384" "ECDH-ECDSA-AES256-SHA384")