### PR TITLE
Allow the service to be manually managed

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,6 +25,7 @@ default['rabbitmq']['server_additional_erl_args'] = nil
 default['rabbitmq']['ctl_erl_args'] = nil
 default['rabbitmq']['mnesiadir'] = '/var/lib/rabbitmq/mnesia'
 default['rabbitmq']['service_name'] = 'rabbitmq-server'
+default['rabbitmq']['manage_service'] = true
 
 # config file location
 # http://www.rabbitmq.com/configure.html#define-environment-variables

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -60,7 +60,7 @@ when 'debian'
   end
 
   # Configure job control
-  if node['rabbitmq']['job_control'] == 'upstart'
+  if node['rabbitmq']['job_control'] == 'upstart' && node['rabbitmq']['manage_service']
     # We start with stock init.d, remove it if we're not using init.d, otherwise leave it alone
     service node['rabbitmq']['service_name'] do
       action [:stop]
@@ -212,8 +212,10 @@ if node['rabbitmq']['cluster'] && (node['rabbitmq']['erlang_cookie'] != existing
   end
 end
 
-service node['rabbitmq']['service_name'] do
-  action [:enable, :start]
-  supports :status => true, :restart => true
-  provider Chef::Provider::Service::Upstart if node['rabbitmq']['job_control'] == 'upstart'
+if node['rabbitmq']['manage_service']
+  service node['rabbitmq']['service_name'] do
+    action [:enable, :start]
+    supports :status => true, :restart => true
+    provider Chef::Provider::Service::Upstart if node['rabbitmq']['job_control'] == 'upstart'
+  end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -218,4 +218,8 @@ if node['rabbitmq']['manage_service']
     supports :status => true, :restart => true
     provider Chef::Provider::Service::Upstart if node['rabbitmq']['job_control'] == 'upstart'
   end
+else
+  service node['rabbitmq']['service_name'] do
+    action :nothing
+  end
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -67,6 +67,16 @@ describe 'rabbitmq::default' do
    )
   end
 
+  it 'does not enable a rabbitmq service when manage_service is false' do
+    node.set['rabbitmq']['manage_service'] = false
+    expect(chef_run).not_to enable_service('rabbitmq-server')
+  end
+
+  it 'does not start a rabbitmq service when manage_service is false' do
+    node.set['rabbitmq']['manage_service'] = false
+    expect(chef_run).not_to start_service('rabbitmq-server')
+  end
+
   it 'enables a rabbitmq service when manage_service is true' do
     node.set['rabbitmq']['manage_service'] = true
     expect(chef_run).to enable_service('rabbitmq-server')
@@ -75,16 +85,6 @@ describe 'rabbitmq::default' do
   it 'starts a rabbitmq service when manage_service is true' do
     node.set['rabbitmq']['manage_service'] = true
     expect(chef_run).to start_service('rabbitmq-server')
-  end
-
-  it 'does not enable a rabbitmq service when manage_service is false' do
-    node.set['rabbitmq']['manage_service'] = true
-    expect(chef_run).not_to enable_service('rabbitmq-server')
-  end
-
-  it 'does not start a rabbitmq service when manage_service is false' do
-    node.set['rabbitmq']['manage_service'] = true
-    expect(chef_run).not_to start_service('rabbitmq-server')
   end
 
   it 'should have the use_distro_version set to false' do

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -67,12 +67,24 @@ describe 'rabbitmq::default' do
    )
   end
 
-  it 'enables a rabbitmq service' do
+  it 'enables a rabbitmq service when manage_service is true' do
+    node.set['rabbitmq']['manage_service'] = true
     expect(chef_run).to enable_service('rabbitmq-server')
   end
 
-  it 'start a rabbitmq service' do
+  it 'starts a rabbitmq service when manage_service is true' do
+    node.set['rabbitmq']['manage_service'] = true
     expect(chef_run).to start_service('rabbitmq-server')
+  end
+
+  it 'does not enable a rabbitmq service when manage_service is false' do
+    node.set['rabbitmq']['manage_service'] = true
+    expect(chef_run).not_to enable_service('rabbitmq-server')
+  end
+
+  it 'does not start a rabbitmq service when manage_service is false' do
+    node.set['rabbitmq']['manage_service'] = true
+    expect(chef_run).not_to start_service('rabbitmq-server')
   end
 
   it 'should have the use_distro_version set to false' do


### PR DESCRIPTION
There are cases where you may want to install rabbitmq, but not start the service immediately.  For instance, when preparing an AMI for AWS, you may want to install all of the software and then when launching the instance only do the configuration.  It is also useful when you want to use systemd instead of the default initd scripts.