### PR TITLE
Fixes issue calling string methods on nil object in cluster provider

### DIFF
--- a/providers/cluster.rb
+++ b/providers/cluster.rb
@@ -80,7 +80,7 @@ end
 def running_nodes(cluster_status)
   pattern = '({running_nodes,\[\'*)(.*?)(\'*\]})'
   match = match_pattern_cluster_status(cluster_status, pattern)
-  result = match && match.gsub(/'/, '').split(',')
+  result = match && match.gsub(/'/, '')
   Chef::Log.debug("[rabbitmq_cluster] running_nodes : #{result}")
   !result.nil? ? result.split(',') : []
 end

--- a/providers/cluster.rb
+++ b/providers/cluster.rb
@@ -80,7 +80,7 @@ end
 def running_nodes(cluster_status)
   pattern = '({running_nodes,\[\'*)(.*?)(\'*\]})'
   match = match_pattern_cluster_status(cluster_status, pattern)
-  result = match && match.gsub!(/'/, '').split(',')
+  result = match && match.gsub(/'/, '').split(',')
   Chef::Log.debug("[rabbitmq_cluster] running_nodes : #{result}")
   !result.nil? ? result.split(',') : []
 end
@@ -89,7 +89,7 @@ end
 def disc_nodes(cluster_status)
   pattern = '({disc,\[\'*)(.*?)(\'*\]})'
   match = match_pattern_cluster_status(cluster_status, pattern)
-  result = match && match.gsub!(/'/, '')
+  result = match && match.gsub(/'/, '')
   Chef::Log.debug("[rabbitmq_cluster] disc_nodes : #{result}")
   !result.nil? ? result.split(',') : []
 end
@@ -98,7 +98,7 @@ end
 def ram_nodes(cluster_status)
   pattern = '({ram,\[\'*)(.*?)(\'*\]})'
   match = match_pattern_cluster_status(cluster_status, pattern)
-  result = match && match.gsub!(/'/, '')
+  result = match && match.gsub(/'/, '')
   Chef::Log.debug("[rabbitmq_cluster] ram_nodes : #{result}")
   !result.nil? ? result.split(',') : []
 end
@@ -111,7 +111,7 @@ def node_name
   cmd = get_shellout(cmd)
   cmd.run_command
   cmd.error!
-  result = cmd.stdout.chomp.gsub!(/'/, '')
+  result = cmd.stdout.chomp.gsub(/'/, '')
   Chef::Log.debug("[rabbitmq_cluster] node name : #{result}")
   result
 end


### PR DESCRIPTION
* Do not use gsub! (edit in place) when we want to capture the return value in the result variable.
* Removes redundant call to split method