### PR TITLE
enable to configure log_levels

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -71,6 +71,9 @@ default['rabbitmq']['clustering']['master_node_name'] = 'rabbit@rabbit1'
 # - Cluster node type : disc | ram
 default['rabbitmq']['clustering']['cluster_node_type'] = 'disc'
 
+# log levels
+default['rabbitmq']['log_levels'] = { 'connection' => 'info' }
+
 # resource usage
 default['rabbitmq']['disk_free_limit_relative'] = nil
 default['rabbitmq']['vm_memory_high_watermark'] = nil

--- a/templates/default/rabbitmq.config.erb
+++ b/templates/default/rabbitmq.config.erb
@@ -50,6 +50,10 @@
 <% else -%>
    {tcp_listeners, []},
 <% end %>
+
+<% if node['rabbitmq']['log_levels'] -%>
+    {log_levels, [<%= node['rabbitmq']['log_levels'].map{ |key, value| "{ #{key}, #{value} }"}.join(', ') %>]},
+<% end %>
 <% if node['rabbitmq']['disk_free_limit_relative'] -%>
     {disk_free_limit, {mem_relative, <%= node['rabbitmq']['disk_free_limit_relative'] %>}},
 <% end %>


### PR DESCRIPTION
I wanted to configure `log_levels` of `rabbitmq.config`. But, I can't set it without creating own new cookbook. So, I added log_levels to rabbitmq.config and set it default value, ` [{connection, info}]`

References: https://www.rabbitmq.com/configure.html