### PR TITLE
Delay start of RabbitMQ on template changes

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -159,7 +159,7 @@ template "#{node['rabbitmq']['config_root']}/rabbitmq-env.conf" do
   owner 'root'
   group 'root'
   mode 00644
-  notifies :restart, "service[#{node['rabbitmq']['service_name']}]", :immediately
+  notifies :restart, "service[#{node['rabbitmq']['service_name']}]"
 end
 
 template "#{node['rabbitmq']['config']}.config" do
@@ -174,7 +174,7 @@ template "#{node['rabbitmq']['config']}.config" do
     :ssl_versions => (format_ssl_versions if node['rabbitmq']['ssl_versions']),
     :ssl_ciphers => (format_ssl_ciphers if node['rabbitmq']['ssl_ciphers'])
   )
-  notifies :restart, "service[#{node['rabbitmq']['service_name']}]", :immediately
+  notifies :restart, "service[#{node['rabbitmq']['service_name']}]"
 end
 
 template "/etc/default/#{node['rabbitmq']['service_name']}" do
@@ -182,7 +182,7 @@ template "/etc/default/#{node['rabbitmq']['service_name']}" do
   owner 'root'
   group 'root'
   mode 00644
-  notifies :restart, "service[#{node['rabbitmq']['service_name']}]", :immediately
+  notifies :restart, "service[#{node['rabbitmq']['service_name']}]"
 end
 
 if File.exist?(node['rabbitmq']['erlang_cookie_path']) && File.readable?((node['rabbitmq']['erlang_cookie_path']))


### PR DESCRIPTION
As mentioned in #245, I do not think the issue of default user/pass changes being disregarded is solved. The fact that notification on the rabbitmq-env.conf template is immediate causes the service to start before the values can be written to the rabbitmq.conf file by the next resource. This changes fixed the problem for me.

I thought perhaps delaying the notifications would cause all sorts of other recipes and LWRP to fail during the initial chef run because the service is not running, but then I noticed that the [service is started](https://github.com/jjasghar/rabbitmq/blob/v4.1.2/recipes/default.rb#L216) down at the bottom of the recipe, so perhaps it is not an issue? It's working for me and my simple wrapper cookbook.