### PR TITLE
rabbitmq.community_plugins default should be {}

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -122,7 +122,7 @@ default['rabbitmq']['disabled_users'] = []
 # plugins
 default['rabbitmq']['enabled_plugins'] = []
 default['rabbitmq']['disabled_plugins'] = []
-default['rabbitmq']['community_plugins'] = nil
+default['rabbitmq']['community_plugins'] = {}
 
 # platform specific settings
 case node['platform_family']


### PR DESCRIPTION
It makes much more sense than `nil`.