### PR TITLE
Use init if job_control uses init.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -225,6 +225,7 @@ if node['rabbitmq']['manage_service']
     action [:enable, :start]
     supports :status => true, :restart => true
     provider Chef::Provider::Service::Upstart if node['rabbitmq']['job_control'] == 'upstart'
+    provider Chef::Provider::Service::Init if node['rabbitmq']['job_control'] == 'init'
   end
 else
   service node['rabbitmq']['service_name'] do


### PR DESCRIPTION
Ubuntu 15.04 machines will otherwise try to use SystemD.