### PR TITLE
Allow the partition handling to be set even if we are not using auto clustering

### DIFF
--- a/templates/default/rabbitmq.config.erb
+++ b/templates/default/rabbitmq.config.erb
@@ -26,6 +26,8 @@
 <% if node['rabbitmq']['cluster'] && node['rabbitmq']['cluster_disk_nodes'] -%>
     <%if node['rabbitmq']['clustering']['use_auto_clustering']-%>
     {cluster_nodes, {[<%= node['rabbitmq']['clustering']['cluster_nodes'].map { |n| "'#{n['name']}'"}.join(',') %>], disc}},
+    <% end %>
+    <%if node['rabbitmq']['clustering']['cluster_partition_handling'] != 'ignore' -%>
     {cluster_partition_handling,<%= node['rabbitmq']['cluster_partition_handling'] %>},
     <% end %>
 <% end %>


### PR DESCRIPTION
I'm currently manually managing my cluster, but would like to be able to specify the cluster_partition_handling setting.  This change allows for it to be set without setting use_auto_clustering.