### PR TITLE
Revert "Upgrade to -3_all.deb"

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,7 +6,7 @@ default['rabbitmq']['use_distro_version'] = false
 default['rabbitmq']['pin_distro_version'] = false
 
 # provide options to override download urls and package names
-default['rabbitmq']['deb_package'] = "rabbitmq-server_#{node['rabbitmq']['version']}-3_all.deb"
+default['rabbitmq']['deb_package'] = "rabbitmq-server_#{node['rabbitmq']['version']}-1_all.deb"
 default['rabbitmq']['deb_package_url'] = "https://www.rabbitmq.com/releases/rabbitmq-server/v#{node['rabbitmq']['version']}/"
 
 default['rabbitmq']['rpm_package'] = "rabbitmq-server-#{node['rabbitmq']['version']}-1.noarch.rpm"

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -184,11 +184,11 @@ describe 'rabbitmq::default' do
     end
 
     it 'creates a rabbitmq-server deb in the cache path' do
-      expect(chef_run).to create_remote_file_if_missing('/tmp/rabbitmq-server_3.5.5-3_all.deb')
+      expect(chef_run).to create_remote_file_if_missing('/tmp/rabbitmq-server_3.5.5-1_all.deb')
     end
 
     it 'installs the rabbitmq-server deb_package with the default action' do
-      expect(chef_run).to install_dpkg_package('/tmp/rabbitmq-server_3.5.5-3_all.deb')
+      expect(chef_run).to install_dpkg_package('/tmp/rabbitmq-server_3.5.5-1_all.deb')
     end
 
     it 'creates a template rabbitmq-server with attributes' do


### PR DESCRIPTION
Reverts jjasghar/rabbitmq#310.

`3.5.5` is the only release that has revision `> 1` for Debian and RPM packages. I think #311 needs to be reverted as it breaks more versions than fixes. `3.5.6` packages have revision of `1`.