### PR TITLE
Add version_release attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,15 +1,16 @@
 # Latest RabbitMQ.com version to install
 default['rabbitmq']['version'] = '3.5.5'
+default['rabbitmq']['version_release'] = '3'
 # The distro versions may be more stable and have back-ported patches
 default['rabbitmq']['use_distro_version'] = false
 # Allow the distro version to be optionally pinned like the rabbitmq.com version
 default['rabbitmq']['pin_distro_version'] = false
 
 # provide options to override download urls and package names
-default['rabbitmq']['deb_package'] = "rabbitmq-server_#{node['rabbitmq']['version']}-1_all.deb"
+default['rabbitmq']['deb_package'] = "rabbitmq-server_#{node['rabbitmq']['version']}-#{default['rabbitmq']['version_release']}_all.deb"
 default['rabbitmq']['deb_package_url'] = "https://www.rabbitmq.com/releases/rabbitmq-server/v#{node['rabbitmq']['version']}/"
 
-default['rabbitmq']['rpm_package'] = "rabbitmq-server-#{node['rabbitmq']['version']}-1.noarch.rpm"
+default['rabbitmq']['rpm_package'] = "rabbitmq-server-#{node['rabbitmq']['version']}-#{default['rabbitmq']['version_release']}.noarch.rpm"
 default['rabbitmq']['rpm_package_url'] = "https://www.rabbitmq.com/releases/rabbitmq-server/v#{node['rabbitmq']['version']}/"
 
 default['rabbitmq']['esl-erlang_package'] = 'esl-erlang-compat-R16B03-1.noarch.rpm?raw=true'


### PR DESCRIPTION
Hi,

got following error when trying to use this cookbook

```
  * remote_file[/var/chef/cache/rabbitmq-server_3.5.5-1_all.deb] action create_if_missing[2015-10-12T11:43:07+00:00] WARN: remote_file[/var/chef/cache/rabbitmq-server_3.5.5-1_all.deb] cannot be downloaded from https://www.rabbitmq.com/releases/rabbitmq-server/v3.5.5/rabbitmq-server_3.5.5-1_all.deb: 404 "Not Found"


    ================================================================================
    Error executing action `create_if_missing` on resource 'remote_file[/var/chef/cache/rabbitmq-server_3.5.5-1_all.deb]'
    ================================================================================
```

Problem is that http://www.rabbitmq.com/releases/rabbitmq-server/v3.5.5/rabbitmq-server_3.5.5-1_all.deb is no longer accessible.

This PR adds `default['rabbitmq']['version_release']` attribute with current release.

Tested and works.
