### PR TITLE
NO-REF Check chef client version before calling sensitive

### DIFF
--- a/providers/user.rb
+++ b/providers/user.rb
@@ -90,7 +90,7 @@ action :add do
     new_password = new_resource.password.gsub("'", "'\\\\''")
     cmd = "rabbitmqctl add_user #{new_resource.user} '#{new_password}'"
     execute "rabbitmqctl add_user #{new_resource.user}" do # ~FC009
-      sensitive true
+      sensitive true if Gem::Version.new(Chef::VERSION.to_s) >= Gem::Version.new('11.14.2')
       command cmd
       Chef::Log.info "Adding RabbitMQ user '#{new_resource.user}'."
     end
@@ -166,7 +166,7 @@ action :change_password do
   if user_exists?(new_resource.user)
     cmd = "rabbitmqctl change_password #{new_resource.user} #{new_resource.password}"
     execute "rabbitmqctl change_password #{new_resource.user}" do # ~FC009
-      sensitive true
+      sensitive true if Gem::Version.new(Chef::VERSION.to_s) >= Gem::Version.new('11.14.2')
       command cmd
       Chef::Log.debug "rabbitmq_user_change_password: #{cmd}"
       Chef::Log.info "Editing RabbitMQ user '#{new_resource.user}'."

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -171,7 +171,7 @@ template "#{node['rabbitmq']['config_root']}/rabbitmq-env.conf" do
 end
 
 template "#{node['rabbitmq']['config']}.config" do
-  sensitive true
+  sensitive true if Gem::Version.new(Chef::VERSION.to_s) >= Gem::Version.new('11.14.2')
   source 'rabbitmq.config.erb'
   cookbook node['rabbitmq']['config_template_cookbook']
   owner 'root'

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -110,6 +110,12 @@ describe 'rabbitmq::default' do
       :group => 'root',
       :source => 'rabbitmq.config.erb',
       :mode => 00644)
+
+    if Gem::Version.new(Chef::VERSION.to_s) >= Gem::Version.new('11.14.2')
+      expect(chef_run).to create_template('/etc/rabbitmq/rabbitmq.config').with(:sensitive => true)
+    else
+      expect(chef_run).to create_template('/etc/rabbitmq/rabbitmq.config').with(:sensitive => false)
+    end
   end
 
   describe 'ssl ciphers' do


### PR DESCRIPTION
This PR is aimed to fix the issue which chef-client with a version less than 11.14 complaining about method `sensitive` missing. My current project requires a chef-client version 11.12 for some reasons, and we can't depend on this rabbitmq cookbook because of the version gap in chef-client.
This fix shouldn't affect any other user but make this cookbook fit into older versions of chef client. We've tested it under chef `11.12` and it works perfect!

Refer to: https://github.com/chef/chef/issues/1744 for more details.
Thanks!