### PR TITLE
fix hardcoded --ram node type for cluster join

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,6 @@ MethodLength:
 
 Style/FileName:
   Enabled: false
+
+Metrics/AbcSize:
+  Max: 16


### PR DESCRIPTION
cc @michaelklishin @jjasghar 

Tested and working:

```
[2015-12-16T01:26:23+00:00] INFO: Processing rabbitmq_cluster[[{"name":"rabbit@ec2-54-201-251-170.us-west-2.compute.amazonaws.com","type":"disc"}]] action join (gz-rabbitmq::join line 5)
[2015-12-16T01:26:23+00:00] INFO: [rabbitmq_cluster] Action join ...
[2015-12-16T01:26:24+00:00] INFO: DOUDOU => rabbit@ec2-54-201-251-170.us-west-2.compute.amazonaws.com
[2015-12-16T01:26:25+00:00] INFO: [rabbitmq_cluster] Clustering node 'rabbit@ec2-54-200-235-67.us-west-2.compute.amazonaws.com' with 'rabbit@ec2-54-201-251-170.us-west-2.compute.amazonaws.com' ...

[2015-12-16T01:26:26+00:00] INFO: [rabbitmq_cluster] Node rabbit@ec2-54-200-235-67.us-west-2.compute.amazonaws.com joined in rabbit@ec2-54-201-251-170.us-west-2.compute.amazonaws.com with type disc
[2015-12-16T01:26:26+00:00] INFO: [{nodes,[{disc,['rabbit@ec2-54-200-235-67.us-west-2.compute.amazonaws.com','rabbit@ec2-54-201-251-170.us-west-2.compute.amazonaws.com']}]},{running_nodes,['rabbit@ec2-54-201-251-170.us-west-2.compute.amazonaws.com','rabbit@ec2-54-200-235-67.us-west-2.compute.amazonaws.com']},{cluster_name,<<"rabbit@ip-10-52-42-243.us-west-2.compute.internal">>},{partitions,[]}]

root@rabbitmq-i-fef72824 ~ # rabbitmqctl cluster_status
Cluster status of node 'rabbit@ec2-54-200-235-67.us-west-2.compute.amazonaws.com' ...
[{nodes,[{disc,['rabbit@ec2-54-200-235-67.us-west-2.compute.amazonaws.com',
                'rabbit@ec2-54-201-251-170.us-west-2.compute.amazonaws.com']}]},
 {running_nodes,['rabbit@ec2-54-201-251-170.us-west-2.compute.amazonaws.com',
                 'rabbit@ec2-54-200-235-67.us-west-2.compute.amazonaws.com']},
 {cluster_name,<<"rabbit@ip-10-52-42-243.us-west-2.compute.internal">>},
 {partitions,[]}]
```