### PR TITLE
Debian Fixes

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -13,6 +13,7 @@ recipe 'rabbitmq::user_management', 'Manage users with node attributes'
 depends 'erlang', '~> 1.5.0'
 depends 'yum-epel'
 depends 'yum-erlang_solutions'
+depends 'dpkg_autostart'
 
 supports 'debian'
 supports 'ubuntu'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -40,14 +40,9 @@ when 'debian'
   # logrotate is a package dependency of rabbitmq-server
   package 'logrotate'
 
-  # dpkg, imma let you finish but don't start services automatically
-  # https://jpetazzo.github.io/2013/10/06/policy-rc-d-do-not-start-services-automatically/
-  execute 'disable auto-start 1/2' do
-    command 'echo exit 101 > /usr/sbin/policy-rc.d'
-  end
-
-  execute 'disable auto-start 2/2' do
-    command 'chmod +x /usr/sbin/policy-rc.d'
+  # => Prevent Debian systems from automatically starting RabbitMQ after dpkg install
+  dpkg_autostart node['rabbitmq']['service_name'] do
+    allow false
   end
 
   if node['rabbitmq']['use_distro_version']
@@ -90,10 +85,6 @@ when 'debian'
       mode 0644
       variables(:max_file_descriptors => node['rabbitmq']['max_file_descriptors'])
     end
-  end
-
-  execute 'undo service disable hack' do
-    command 'echo exit 0 > /usr/sbin/policy-rc.d'
   end
 
 when 'rhel', 'fedora'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -57,8 +57,10 @@ when 'debian'
       source deb_package
       action :create_if_missing
     end
-    dpkg_package "#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['deb_package']}" do
-      action :install
+    package 'rabbitmq-server' do
+      provider Chef::Provider::Package::Dpkg
+      source ::File.join(Chef::Config[:file_cache_path], node['rabbitmq']['deb_package'])
+      action :upgrade
     end
   end
 

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -185,16 +185,6 @@ describe 'rabbitmq::default' do
     include_context 'rabbitmq-stubs'
 
     # ~FC005 -- we should ignore this during compile time
-    it 'should autostart via the exit 101' do
-      expect(chef_run).to run_execute('disable auto-start 1/2')
-    end
-
-    # ~FC005 -- we should ignore this during compile time
-    it 'should disable the autostart 2/2' do
-      expect(chef_run).to run_execute('disable auto-start 2/2')
-    end
-
-    # ~FC005 -- we should ignore this during compile time
     it 'should install the logrotate package' do
       expect(chef_run).to install_package('logrotate')
     end
@@ -204,7 +194,7 @@ describe 'rabbitmq::default' do
     end
 
     it 'installs the rabbitmq-server deb_package with the default action' do
-      expect(chef_run).to install_dpkg_package('/tmp/rabbitmq-server_3.5.6-1_all.deb')
+      expect(chef_run).to upgrade_package('rabbitmq-server')
     end
 
     it 'creates a template rabbitmq-server with attributes' do
@@ -213,10 +203,6 @@ describe 'rabbitmq::default' do
         :group => 'root',
         :source => 'default.rabbitmq-server.erb',
         :mode => 00644)
-    end
-
-    it 'should undo the service disable hack' do
-      expect(chef_run).to run_execute('undo service disable hack')
     end
 
     describe 'uses distro version' do


### PR DESCRIPTION
Fixes/Enhancements:
- use `dpkg_autostart` to cleanly prevent dpkg from automatically running RabbitMQ after installation
- Make the Debian installation behave more like RedHat by allowing package upgrades
