### PR TITLE
Fix user grep command to match whitespace

### DIFF
--- a/providers/user.rb
+++ b/providers/user.rb
@@ -20,7 +20,7 @@
 use_inline_resources
 
 def user_exists?(name)
-  cmd = "rabbitmqctl -q list_users |grep '^#{name}\\b'"
+  cmd = "rabbitmqctl -q list_users |grep '^#{name}\\s'"
   cmd = Mixlib::ShellOut.new(cmd)
   cmd.environment['HOME'] = ENV.fetch('HOME', '/root')
   cmd.run_command


### PR DESCRIPTION
Original \b matches a word, but a hyphen is not respected, which causes 'user' to match 'user-whatever'. Replacing the \b with \s to match the whitespace instead.