### PR TITLE
Package install logrotate for *.log

### DIFF
--- a/templates/default/rabbitmq.upstart.conf.erb
+++ b/templates/default/rabbitmq.upstart.conf.erb
@@ -19,7 +19,7 @@ pre-start script
     fi
 end script
 
-exec /usr/sbin/rabbitmq-server > /var/log/rabbitmq/startup_log \
-                              2> /var/log/rabbitmq/startup_err
+exec /usr/sbin/rabbitmq-server > /var/log/rabbitmq/startup.log \
+                              2> /var/log/rabbitmq/startup_err.log
 
 post-start exec /usr/sbin/rabbitmqctl wait $RABBITMQ_PID_FILE >/dev/null 2>&1


### PR DESCRIPTION
Related to #338. By default package only rotates logs in /var/log/rabbitmq/*.log. Direct solution is to rename logs names. Other solution is to depend on logrotate cookbook. Dunno which is best.