### PR TITLE
simplified clustering logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The release was tested with (rabbitmq.com/distro version), from the [kitchen.yml
 ### default
 Installs `rabbitmq-server` from RabbitMQ.com via direct download of the installation package or using the distribution version. Depending on your distribution, the provided version may be quite old so they are disabled by default. If you want to use the distro version, set the attribute `['rabbitmq']['use_distro_version']` to `true`. You may override the download URL attribute `['rabbitmq']['package']` if you wish to use a local mirror.
 
-The cluster recipe is now combined with the default and will now auto-cluster. Set the `['rabbitmq']['cluster']` attribute to `true`, `['rabbitmq']['cluster_disk_nodes']` array of `node@host` strings that describe which you want to be disk nodes and then set an alphanumeric string for the `erlang_cookie`.
+The cluster recipe is now combined with the default and will now auto-cluster. Set the `['rabbitmq']['clustering']['enabled']` attribute to `true`, `['rabbitmq']['clustering']['cluster_disk_nodes']` array of `node@host` strings that describe which you want to be disk nodes and then set an alphanumeric string for the `erlang_cookie`.
 
 To enable SSL turn `ssl` to `true` and set the paths to your cacert, cert and key files.
 ```ruby
@@ -81,7 +81,7 @@ Configure the cluster between the nodes in the `node['rabbitmq']['clustering']['
 * Manual clustering : Configure the cluster by executing `rabbitmqctl join_cluster` command.
 
 #### Attributes that related to clustering
-* `node['rabbitmq']['cluster']` : Default decision flag of clustering
+* `node['rabbitmq']['clustering']['enable']` : Default decision flag of clustering
 * `node['rabbitmq']['erlang_cookie']` : Same erlang cookie is required for the cluster
 * `node['rabbitmq']['clustering']['use_auto_clustering']` : Default is false. (manual clustering is default)
 * `node['rabbitmq']['clustering']['cluster_name']` : Name of cluster. default value is nil. In case of nil or '' is set for `cluster_name`, first node name in `node['rabbitmq']['clustering']['cluster_nodes']` attribute will be set for manual clustering. for the auto clustering, one of the node name will be set.
@@ -89,9 +89,9 @@ Configure the cluster between the nodes in the `node['rabbitmq']['clustering']['
 
 Attributes example
 ```ruby
-node['rabbitmq']['cluster'] = true
+node['rabbitmq']['clustering']['enable'] = true
 node['rabbitmq']['erlang_cookie'] = 'AnyAlphaNumericStringWillDo'
-node['rabbitmq']['cluster_partition_handling'] = 'ignore'
+node['rabbitmq']['clustering']['cluster_partition_handling'] = 'ignore'
 node['rabbitmq']['clustering']['use_auto_clustering'] = false
 node['rabbitmq']['clustering']['cluster_name'] = 'seoul_tokyo_newyork'
 node['rabbitmq']['clustering']['cluster_nodes'] = [

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,9 +16,9 @@ default['rabbitmq']['esl-erlang_package'] = 'esl-erlang-compat-R16B03-1.noarch.r
 default['rabbitmq']['esl-erlang_package_url'] = 'https://github.com/jasonmcintosh/esl-erlang-compat/blob/master/rpmbuild/RPMS/noarch/'
 
 # being nil, the rabbitmq defaults will be used
-default['rabbitmq']['nodename']  = nil
-default['rabbitmq']['address']  = nil
-default['rabbitmq']['port']  = nil
+default['rabbitmq']['nodename'] = nil
+default['rabbitmq']['address'] = nil
+default['rabbitmq']['port'] = nil
 default['rabbitmq']['config'] = nil
 default['rabbitmq']['logdir'] = nil
 default['rabbitmq']['server_additional_erl_args'] = nil
@@ -33,6 +33,7 @@ default['rabbitmq']['manage_service'] = true
 default['rabbitmq']['config_root'] = '/etc/rabbitmq'
 default['rabbitmq']['config'] = "#{node['rabbitmq']['config_root']}/rabbitmq"
 default['rabbitmq']['erlang_cookie_path'] = '/var/lib/rabbitmq/.erlang.cookie'
+default['rabbitmq']['erlang_cookie'] = 'AnyAlphaNumericStringWillDo'
 # override this if you wish to provide `rabbitmq.config.erb` in your own wrapper cookbook
 default['rabbitmq']['config_template_cookbook'] = 'rabbitmq'
 
@@ -54,10 +55,8 @@ default['rabbitmq']['kernel']['inet_dist_listen_max'] = nil
 default['rabbitmq']['kernel']['inet_dist_use_interface'] = nil
 
 # clustering
-default['rabbitmq']['cluster'] = false
-default['rabbitmq']['cluster_disk_nodes'] = []
-default['rabbitmq']['erlang_cookie'] = 'AnyAlphaNumericStringWillDo'
-default['rabbitmq']['cluster_partition_handling'] = 'ignore'
+default['rabbitmq']['clustering']['enable'] = false
+default['rabbitmq']['clustering']['cluster_partition_handling'] = 'ignore'
 
 default['rabbitmq']['clustering']['use_auto_clustering'] = false
 default['rabbitmq']['clustering']['cluster_name'] = nil
@@ -105,7 +104,7 @@ default['rabbitmq']['web_console_ssl_port'] = 15_671
 # tcp listen options
 default['rabbitmq']['tcp_listen'] = true
 default['rabbitmq']['tcp_listen_packet'] = 'raw'
-default['rabbitmq']['tcp_listen_reuseaddr']  = true
+default['rabbitmq']['tcp_listen_reuseaddr'] = true
 default['rabbitmq']['tcp_listen_backlog'] = 128
 default['rabbitmq']['tcp_listen_nodelay'] = true
 default['rabbitmq']['tcp_listen_exit_on_close'] = false

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -22,7 +22,7 @@ module Opscode
     # This method does some of the yuckiness of formatting parameters properly
     # for rendering into the rabbit.config template.
     def format_kernel_parameters  # rubocop:disable all
-      rendered = []   # rubocop:enable all
+      rendered = [] # rubocop:enable all
       kernel = node['rabbitmq']['kernel'].dup
 
       # This parameter is special and needs commas instead of periods.

--- a/providers/cluster.rb
+++ b/providers/cluster.rb
@@ -80,7 +80,7 @@ end
 def running_nodes(cluster_status)
   pattern = '({running_nodes,\[\'*)(.*?)(\'*\]})'
   match = match_pattern_cluster_status(cluster_status, pattern)
-  result = match && match.gsub(/'/, '')
+  result = match && match.delete("'")
   Chef::Log.debug("[rabbitmq_cluster] running_nodes : #{result}")
   result.nil? ? [] : result
 end
@@ -89,7 +89,7 @@ end
 def disc_nodes(cluster_status)
   pattern = '({disc,\[\'*)(.*?)(\'*\]})'
   match = match_pattern_cluster_status(cluster_status, pattern)
-  result = match && match.gsub(/'/, '').split(',')
+  result = match && match.delete("'").split(',')
   Chef::Log.debug("[rabbitmq_cluster] disc_nodes : #{result}")
   result.nil? ? [] : result
 end
@@ -98,7 +98,7 @@ end
 def ram_nodes(cluster_status)
   pattern = '({ram,\[\'*)(.*?)(\'*\]})'
   match = match_pattern_cluster_status(cluster_status, pattern)
-  result = match && match.gsub(/'/, '').split(',')
+  result = match && match.delete("'").split(',')
   Chef::Log.debug("[rabbitmq_cluster] ram_nodes : #{result}")
   result.nil? ? [] : result
 end
@@ -111,7 +111,7 @@ def node_name
   cmd = get_shellout(cmd)
   cmd.run_command
   cmd.error!
-  result = cmd.stdout.chomp.gsub(/'/, '')
+  result = cmd.stdout.chomp.delete("'")
   Chef::Log.debug("[rabbitmq_cluster] node name : #{result}")
   result
 end

--- a/providers/vhost.rb
+++ b/providers/vhost.rb
@@ -45,7 +45,7 @@ end
 
 action :delete do
   if vhost_exists?(new_resource.vhost)
-    cmd =  "rabbitmqctl delete_vhost #{new_resource.vhost}"
+    cmd = "rabbitmqctl delete_vhost #{new_resource.vhost}"
     execute cmd do
       Chef::Log.debug "rabbitmq_vhost_delete: #{cmd}"
       Chef::Log.info "Deleting RabbitMQ vhost '#{new_resource.vhost}'."

--- a/recipes/cluster.rb
+++ b/recipes/cluster.rb
@@ -24,21 +24,20 @@ include_recipe 'rabbitmq::default'
 cluster_nodes = node['rabbitmq']['clustering']['cluster_nodes']
 cluster_nodes = cluster_nodes.to_json
 
-if node['rabbitmq']['cluster']
-  # Manual clustering
-  unless node['rabbitmq']['clustering']['use_auto_clustering']
-    # Join in cluster
-    rabbitmq_cluster cluster_nodes do
-      action :join
-    end
-  end
-  # Set cluster name : It will be skipped once same cluster name has been set in the cluster.
+# Manual clustering
+unless node['rabbitmq']['clustering']['use_auto_clustering']
+  # Join in cluster
   rabbitmq_cluster cluster_nodes do
-    cluster_name node['rabbitmq']['clustering']['cluster_name']
-    action :set_cluster_name
+    action :join
   end
-  # Change the cluster node type
-  rabbitmq_cluster cluster_nodes do
-    action :change_cluster_node_type
-  end
+end
+
+# Set cluster name : It will be skipped once same cluster name has been set in the cluster.
+rabbitmq_cluster cluster_nodes do
+  cluster_name node['rabbitmq']['clustering']['cluster_name']
+  action :set_cluster_name
+end
+# Change the cluster node type
+rabbitmq_cluster cluster_nodes do
+  action :change_cluster_node_type
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -194,12 +194,12 @@ template "/etc/default/#{node['rabbitmq']['service_name']}" do
 end
 
 if File.exist?(node['rabbitmq']['erlang_cookie_path']) && File.readable?((node['rabbitmq']['erlang_cookie_path']))
-  existing_erlang_key =  File.read(node['rabbitmq']['erlang_cookie_path']).strip
+  existing_erlang_key = File.read(node['rabbitmq']['erlang_cookie_path']).strip
 else
   existing_erlang_key = ''
 end
 
-if node['rabbitmq']['cluster'] && (node['rabbitmq']['erlang_cookie'] != existing_erlang_key)
+if node['rabbitmq']['clustering']['enable'] && (node['rabbitmq']['erlang_cookie'] != existing_erlang_key)
   log "stop #{node['rabbitmq']['service_name']} to change erlang cookie" do
     notifies :stop, "service[#{node['rabbitmq']['service_name']}]", :immediately
   end

--- a/recipes/user_management.rb
+++ b/recipes/user_management.rb
@@ -31,7 +31,7 @@ node['rabbitmq']['enabled_users'].each do |user|
     tag user['tag']
     action :set_tags
   end
-  user['rights'].each  do |r|
+  user['rights'].each do |r|
     rabbitmq_user user['name'] do
       vhost r['vhost']
       permissions "#{r['conf']} #{r['write']} #{r['read']}"

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -60,11 +60,12 @@ describe 'rabbitmq::default' do
   end
 
   it 'should create the directory /var/lib/rabbitmq/mnesia' do
-    expect(chef_run).to create_directory('/var/lib/rabbitmq/mnesia').with(
-      :user => 'rabbitmq',
-      :group => 'rabbitmq',
-      :mode => '775'
-   )
+    expect(chef_run).to create_directory('/var/lib/rabbitmq/mnesia')
+      .with(
+        :user => 'rabbitmq',
+        :group => 'rabbitmq',
+        :mode => '775'
+      )
   end
 
   it 'does not enable a rabbitmq service when manage_service is false' do

--- a/templates/default/rabbitmq.config.erb
+++ b/templates/default/rabbitmq.config.erb
@@ -23,13 +23,11 @@
   {ssl, [{versions, [<%= @ssl_versions %>]}]},
 <% end %>
   {rabbit, [
-<% if node['rabbitmq']['cluster'] && node['rabbitmq']['cluster_disk_nodes'] -%>
-    <%if node['rabbitmq']['clustering']['use_auto_clustering']-%>
-    {cluster_nodes, {[<%= node['rabbitmq']['clustering']['cluster_nodes'].map { |n| "'#{n['name']}'"}.join(',') %>], disc}},
+<% if node['rabbitmq']['clustering']['enable'] -%>
+    <%if node['rabbitmq']['clustering']['use_auto_clustering'] -%>
+    {cluster_nodes, {[<%= node['rabbitmq']['clustering']['cluster_nodes'].map { |n| "'#{n}'"}.join(',') %>], disc}},
     <% end %>
-    <%if node['rabbitmq']['clustering']['cluster_partition_handling'] != 'ignore' -%>
-    {cluster_partition_handling,<%= node['rabbitmq']['cluster_partition_handling'] %>},
-    <% end %>
+    {cluster_partition_handling,<%= node['rabbitmq']['clustering']['cluster_partition_handling'] %>},
 <% end %>
 <% if node['rabbitmq']['ssl'] -%>
     {ssl_listeners, [<%= node['rabbitmq']['ssl_port'] %>]},


### PR DESCRIPTION
* removed check if clustering enabled in cluster recipes since this should not
  be needed
* streamlined clustering attributes
* simplified logic in rabbitmq.config template for clustering
* adapted README
* fixed some rubocop offenses