### PR TITLE
added an example to the "user_management" section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,25 @@ Enables any policies listed in the `node['rabbitmq']['policies']` and disables a
 
 ### user_management
 Enables any users listed in the `node['rabbitmq']['enabled_users']` and disables any listed in `node['rabbitmq']['disabled_users']` attributes.
+You can provide user credentials, the vhosts that they need to have access to and the permissions that should be allocated to each user.
+
+```ruby
+node['rabbitmq']['enabled_users'] = [
+    {
+        :name => 'kitten',
+        :password => 'kitten',
+        :tag => 'leader',
+        :rights => [
+            {
+                :vhost => ['/', 'nova'],
+                :conf => '.*',
+                :write => '.*',
+                :read => '.*'
+            }
+        ]
+    }
+]
+```
 
 ### virtualhost_management
 Enables any vhosts listed in the `node['rabbitmq']['virtualhosts']` and disables any listed in `node['rabbitmq']['disabled_virtualhosts']` attributes.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -76,6 +76,7 @@ default['rabbitmq']['log_levels'] = { 'connection' => 'info' }
 
 # resource usage
 default['rabbitmq']['disk_free_limit_relative'] = nil
+default['rabbitmq']['disk_free_limit'] = nil
 default['rabbitmq']['vm_memory_high_watermark'] = nil
 default['rabbitmq']['max_file_descriptors'] = 1024
 default['rabbitmq']['open_file_limit'] = nil

--- a/templates/default/rabbitmq.config.erb
+++ b/templates/default/rabbitmq.config.erb
@@ -60,6 +60,13 @@
 <% if node['rabbitmq']['disk_free_limit_relative'] -%>
     {disk_free_limit, {mem_relative, <%= node['rabbitmq']['disk_free_limit_relative'] %>}},
 <% end %>
+<% if node['rabbitmq']['disk_free_limit'] %>
+    <% if node['rabbitmq']['disk_free_limit'].is_a? String %>
+    {disk_free_limit, "<%= node['rabbitmq']['disk_free_limit'] %>"},
+    <%elsif node['rabbitmq']['disk_free_limit'].is_a? Integer %>
+    {disk_free_limit, <%= node['rabbitmq']['disk_free_limit'] %>},
+    <% end %>
+<% end %>
 <% if node['rabbitmq']['vm_memory_high_watermark'] -%>
     {vm_memory_high_watermark, <%= node['rabbitmq']['vm_memory_high_watermark'] %>},
 <% end %>


### PR DESCRIPTION
The example demonstrator how using the node attributes we can
add a user with attributes needed to have access to one or more
ghosts.