### PR TITLE
Pass a HOME environment variable to all rabbitmq execute blocks

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -46,5 +46,9 @@ module Opscode
     def format_ssl_ciphers
       Array(node['rabbitmq']['ssl_ciphers']).join(',')
     end
+
+    def shell_environment
+      { 'HOME' => ENV.fetch('HOME', '/var/lib/rabbitmq') }
+    end
   end
 end

--- a/providers/cluster.rb
+++ b/providers/cluster.rb
@@ -18,6 +18,7 @@
 # limitations under the License.
 #
 
+include Opscode::RabbitMQ
 include Chef::Mixin::ShellOut
 
 use_inline_resources
@@ -25,7 +26,7 @@ use_inline_resources
 # Get ShellOut
 def get_shellout(cmd)
   sh_cmd = Mixlib::ShellOut.new(cmd)
-  sh_cmd.environment['HOME'] = ENV.fetch('HOME', '/root')
+  sh_cmd.environment = shell_environment
   sh_cmd
 end
 

--- a/providers/parameter.rb
+++ b/providers/parameter.rb
@@ -20,13 +20,15 @@
 
 require 'shellwords'
 
+include Opscode::RabbitMQ
+
 def parameter_exists?(vhost, name)
   cmd = 'rabbitmqctl list_parameters'
   cmd << " -p #{Shellwords.escape vhost}" unless vhost.nil?
   cmd << " |grep '#{name}\\b'"
 
   cmd = Mixlib::ShellOut.new(cmd)
-  cmd.environment['HOME'] = ENV.fetch('HOME', '/root')
+  cmd.environment = shell_environment
   cmd.run_command
   begin
     cmd.error!
@@ -51,6 +53,7 @@ action :set do
 
     execute "set_parameter #{parameter}" do
       command cmd
+      environment shell_environment
     end
 
     new_resource.updated_by_last_action(true)
@@ -64,6 +67,7 @@ action :clear do
 
     execute "clear_parameter #{parameter}" do
       command "rabbitmqctl clear_parameter #{parameter}"
+      environment shell_environment
     end
 
     new_resource.updated_by_last_action(true)
@@ -74,6 +78,7 @@ end
 action :list do
   execute 'list_parameters' do
     command 'rabbitmqctl list_parameters'
+    environment shell_environment
   end
 
   new_resource.updated_by_last_action(true)

--- a/providers/plugin.rb
+++ b/providers/plugin.rb
@@ -17,11 +17,13 @@
 # limitations under the License.
 #
 
+include Opscode::RabbitMQ
+
 def plugin_enabled?(name)
   ENV['PATH'] = "#{ENV['PATH']}:/usr/lib/rabbitmq/bin"
   cmdstr = "rabbitmq-plugins list -e '#{name}\\b'"
   cmd = Mixlib::ShellOut.new(cmdstr)
-  cmd.environment['HOME'] = ENV.fetch('HOME', '/root')
+  cmd.environment = shell_environment
   cmd.run_command
   Chef::Log.debug "rabbitmq_plugin_enabled?: #{cmdstr}"
   Chef::Log.debug "rabbitmq_plugin_enabled?: #{cmd.stdout}"
@@ -36,7 +38,9 @@ action :enable do
     execute "rabbitmq-plugins enable #{new_resource.plugin}" do
       umask 0022
       Chef::Log.info "Enabling RabbitMQ plugin '#{new_resource.plugin}'."
-      environment 'PATH' => "#{ENV['PATH']}:/usr/lib/rabbitmq/bin"
+      environment shell_environment.merge(
+                    'PATH' => "#{ENV['PATH']}:/usr/lib/rabbitmq/bin"
+                  )
       new_resource.updated_by_last_action(true)
     end
   end
@@ -47,7 +51,9 @@ action :disable do
     execute "rabbitmq-plugins disable #{new_resource.plugin}" do
       umask 0022
       Chef::Log.info "Disabling RabbitMQ plugin '#{new_resource.plugin}'."
-      environment 'PATH' => "#{ENV['PATH']}:/usr/lib/rabbitmq/bin"
+      environment shell_environment.merge(
+                    'PATH' => "#{ENV['PATH']}:/usr/lib/rabbitmq/bin"
+                  )
       new_resource.updated_by_last_action(true)
     end
   end

--- a/providers/policy.rb
+++ b/providers/policy.rb
@@ -20,13 +20,15 @@
 
 require 'shellwords'
 
+include Opscode::RabbitMQ
+
 def policy_exists?(vhost, name)
   cmd = 'rabbitmqctl list_policies'
   cmd << " -p #{Shellwords.escape vhost}" unless vhost.nil?
   cmd << " |grep '#{name}\\b'"
 
   cmd = Mixlib::ShellOut.new(cmd)
-  cmd.environment['HOME'] = ENV.fetch('HOME', '/root')
+  cmd.environment = shell_environment
   cmd.run_command
   begin
     cmd.error!
@@ -66,6 +68,7 @@ action :set do
 
     execute "set_policy #{new_resource.policy}" do
       command cmd
+      environment shell_environment
     end
 
     new_resource.updated_by_last_action(true)
@@ -79,6 +82,7 @@ action :clear do
     cmd << " -p #{new_resource.vhost}" unless new_resource.vhost.nil?
     execute "clear_policy #{new_resource.policy}" do
       command cmd
+      environment shell_environment
     end
 
     new_resource.updated_by_last_action(true)
@@ -89,6 +93,7 @@ end
 action :list do
   execute 'list_policies' do
     command 'rabbitmqctl list_policies'
+    environment shell_environment
   end
 
   new_resource.updated_by_last_action(true)

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -17,12 +17,14 @@
 # limitations under the License.
 #
 
+include Opscode::RabbitMQ
+
 use_inline_resources
 
 def user_exists?(name)
   cmd = "rabbitmqctl -q list_users |grep '^#{name}\\s'"
   cmd = Mixlib::ShellOut.new(cmd)
-  cmd.environment['HOME'] = ENV.fetch('HOME', '/root')
+  cmd.environment = shell_environment
   cmd.run_command
   Chef::Log.debug "rabbitmq_user_exists?: #{cmd}"
   Chef::Log.debug "rabbitmq_user_exists?: #{cmd.stdout}"
@@ -37,7 +39,7 @@ end
 def user_has_tag?(name, tag) # rubocop:disable all
   cmd = 'rabbitmqctl -q list_users'
   cmd = Mixlib::ShellOut.new(cmd)
-  cmd.environment['HOME'] = ENV.fetch('HOME', '/root')
+  cmd.environment = shell_environment
   cmd.run_command
   user_list = cmd.stdout
   tags = user_list.match(/^#{name}\s+\[(.*?)\]/)[1].split
@@ -61,7 +63,7 @@ def user_has_permissions?(name, vhost, perm_list = nil) # rubocop:disable all
   vhost = '/' if vhost.nil? # rubocop:enable all
   cmd = "rabbitmqctl -q list_user_permissions #{name} | grep \"^#{vhost}\\s\""
   cmd = Mixlib::ShellOut.new(cmd)
-  cmd.environment['HOME'] = ENV.fetch('HOME', '/root')
+  cmd.environment = shell_environment
   cmd.run_command
   Chef::Log.debug "rabbitmq_user_has_permissions?: #{cmd}"
   Chef::Log.debug "rabbitmq_user_has_permissions?: #{cmd.stdout}"
@@ -92,6 +94,7 @@ action :add do
     execute "rabbitmqctl add_user #{new_resource.user}" do # ~FC009
       sensitive true if Gem::Version.new(Chef::VERSION.to_s) >= Gem::Version.new('11.14.2')
       command cmd
+      environment shell_environment
       Chef::Log.info "Adding RabbitMQ user '#{new_resource.user}'."
     end
   end
@@ -101,6 +104,7 @@ action :delete do
   if user_exists?(new_resource.user)
     cmd = "rabbitmqctl delete_user #{new_resource.user}"
     execute cmd do
+      environment shell_environment
       Chef::Log.debug "rabbitmq_user_delete: #{cmd}"
       Chef::Log.info "Deleting RabbitMQ user '#{new_resource.user}'."
     end
@@ -117,6 +121,7 @@ action :set_permissions do
     vhostopt = "-p #{vhost}" unless vhost.nil?
     cmd = "rabbitmqctl set_permissions #{vhostopt} #{new_resource.user} \"#{perm_list.join("\" \"")}\""
     execute cmd do
+      environment shell_environment
       Chef::Log.debug "rabbitmq_user_set_permissions: #{cmd}"
       Chef::Log.info "Setting RabbitMQ user permissions for '#{new_resource.user}' on vhost #{vhost}."
     end
@@ -132,6 +137,7 @@ action :clear_permissions do
     vhostopt = "-p #{vhost}" unless vhost.nil?
     cmd = "rabbitmqctl clear_permissions #{vhostopt} #{new_resource.user}"
     execute cmd do
+      environment shell_environment
       Chef::Log.debug "rabbitmq_user_clear_permissions: #{cmd}"
       Chef::Log.info "Clearing RabbitMQ user permissions for '#{new_resource.user}' from vhost #{vhost}."
     end
@@ -144,6 +150,7 @@ action :set_tags do
   unless user_has_tag?(new_resource.user, new_resource.tag)
     cmd = "rabbitmqctl set_user_tags #{new_resource.user} #{new_resource.tag}"
     execute cmd do
+      environment shell_environment
       Chef::Log.debug "rabbitmq_user_set_tags: #{cmd}"
       Chef::Log.info "Setting RabbitMQ user '#{new_resource.user}' tags '#{new_resource.tag}'"
     end
@@ -156,6 +163,7 @@ action :clear_tags do
   unless user_has_tag?(new_resource.user, '"\[\]"')
     cmd = "rabbitmqctl set_user_tags #{new_resource.user}"
     execute cmd do
+      environment shell_environment
       Chef::Log.debug "rabbitmq_user_clear_tags: #{cmd}"
       Chef::Log.info "Clearing RabbitMQ user '#{new_resource.user}' tags."
     end
@@ -168,6 +176,7 @@ action :change_password do
     execute "rabbitmqctl change_password #{new_resource.user}" do # ~FC009
       sensitive true if Gem::Version.new(Chef::VERSION.to_s) >= Gem::Version.new('11.14.2')
       command cmd
+      environment shell_environment
       Chef::Log.debug "rabbitmq_user_change_password: #{cmd}"
       Chef::Log.info "Editing RabbitMQ user '#{new_resource.user}'."
     end

--- a/providers/vhost.rb
+++ b/providers/vhost.rb
@@ -17,10 +17,12 @@
 # limitations under the License.
 #
 
+include Opscode::RabbitMQ
+
 def vhost_exists?(name)
   cmd = "rabbitmqctl -q list_vhosts | grep ^#{name}$"
   cmd = Mixlib::ShellOut.new(cmd)
-  cmd.environment['HOME'] = ENV.fetch('HOME', '/root')
+  cmd.environment = shell_environment
   cmd.run_command
   Chef::Log.debug "rabbitmq_vhost_exists?: #{cmd}"
   Chef::Log.debug "rabbitmq_vhost_exists?: #{cmd.stdout}"
@@ -38,6 +40,7 @@ action :add do
     execute cmd do
       Chef::Log.debug "rabbitmq_vhost_add: #{cmd}"
       Chef::Log.info "Adding RabbitMQ vhost '#{new_resource.vhost}'."
+      environment shell_environment
       new_resource.updated_by_last_action(true)
     end
   end
@@ -49,6 +52,7 @@ action :delete do
     execute cmd do
       Chef::Log.debug "rabbitmq_vhost_delete: #{cmd}"
       Chef::Log.info "Deleting RabbitMQ vhost '#{new_resource.vhost}'."
+      environment shell_environment
       new_resource.updated_by_last_action(true)
     end
   end


### PR DESCRIPTION
I ran into https://github.com/jjasghar/rabbitmq/issues/334 today when rolling some new Rabbitmq servers. Since the `ShellOut`s are already ensuring the presence of a `HOME` environment variable, it seemed logical to have the `execute` blocks do the same. Agree/disagree/thoughts?

Thanks!