### PR TITLE
Update cipher examples

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -96,8 +96,10 @@ default['rabbitmq']['ssl_fail_if_no_peer_cert'] = false
 #   ['tlsv1.2', 'tlsv1.1']
 default['rabbitmq']['ssl_versions'] = nil
 # Specify SSL ciphers
-# Example:
-#   ['ecdhe_ecdsa,aes_128_cbc,sha256', 'ecdhe_ecdsa,aes_256_cbc,sha']
+# Examples:
+# ['{ecdhe_ecdsa,aes_128_cbc,sha256}', '{ecdhe_ecdsa,aes_256_cbc,sha}']
+# or in OpenSSL format:
+# ['"ECDHE-ECDSA-AES128-SHA256"', '"ECDHE-ECDSA-AES256-SHA"']
 default['rabbitmq']['ssl_ciphers'] = nil
 default['rabbitmq']['web_console_ssl'] = false
 default['rabbitmq']['web_console_ssl_port'] = 15_671


### PR DESCRIPTION

This PR matches the example ciphers in the attributes file to the current rspec tests.

https://github.com/jjasghar/rabbitmq/pull/260/commits/4480a86b7b5c8f5a109a4ea9b403493e00ae220f was a backwards compatibility breaking change for me. I'm not sure if it's the version of rabbit that I'm using, but the only valid configuration I get is when the openssl ciphers are double quoted (not single quoted) or the standard cipher strings are wrapped in curly braces. It was previously valid to just specify the cipher suite as an array of strings so long as they weren't in the Openssl format, now they must be an array of curly brace wrapped strings.

These examples would have made it a lot quicker to realise there was a change. 

I would ask that you please increment the metadata version by a major version increment if backward compatibility breaking changes are introduced, so that the pessimistic matcher can work (i.e. depends 'rabbitmq', '~> 0.1')