### PR TITLE
Fixes #375. Assign environment via constructor.

### DIFF
--- a/providers/cluster.rb
+++ b/providers/cluster.rb
@@ -25,8 +25,7 @@ use_inline_resources
 
 # Get ShellOut
 def get_shellout(cmd)
-  sh_cmd = Mixlib::ShellOut.new(cmd)
-  sh_cmd.environment = shell_environment
+  sh_cmd = Mixlib::ShellOut.new(cmd, :env => shell_environment)
   sh_cmd
 end
 

--- a/providers/parameter.rb
+++ b/providers/parameter.rb
@@ -29,8 +29,7 @@ def parameter_exists?(vhost, name)
   cmd << " -p #{Shellwords.escape vhost}" unless vhost.nil?
   cmd << " |grep '#{name}\\b'"
 
-  cmd = Mixlib::ShellOut.new(cmd)
-  cmd.environment = shell_environment
+  cmd = Mixlib::ShellOut.new(cmd, :env => shell_environment)
   cmd.run_command
   begin
     cmd.error!

--- a/providers/plugin.rb
+++ b/providers/plugin.rb
@@ -22,8 +22,7 @@ include Opscode::RabbitMQ
 def plugin_enabled?(name)
   ENV['PATH'] = "#{ENV['PATH']}:/usr/lib/rabbitmq/bin"
   cmdstr = "rabbitmq-plugins list -e '#{name}\\b'"
-  cmd = Mixlib::ShellOut.new(cmdstr)
-  cmd.environment = shell_environment
+  cmd = Mixlib::ShellOut.new(cmdstr, :env => shell_environment)
   cmd.run_command
   Chef::Log.debug "rabbitmq_plugin_enabled?: #{cmdstr}"
   Chef::Log.debug "rabbitmq_plugin_enabled?: #{cmd.stdout}"

--- a/providers/policy.rb
+++ b/providers/policy.rb
@@ -29,8 +29,7 @@ def policy_exists?(vhost, name)
   cmd << " -p #{Shellwords.escape vhost}" unless vhost.nil?
   cmd << " |grep '#{name}\\b'"
 
-  cmd = Mixlib::ShellOut.new(cmd)
-  cmd.environment = shell_environment
+  cmd = Mixlib::ShellOut.new(cmd, :env => shell_environment)
   cmd.run_command
   begin
     cmd.error!

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -23,8 +23,7 @@ use_inline_resources
 
 def user_exists?(name)
   cmd = "rabbitmqctl -q list_users |grep '^#{name}\\s'"
-  cmd = Mixlib::ShellOut.new(cmd)
-  cmd.environment = shell_environment
+  cmd = Mixlib::ShellOut.new(cmd, :env => shell_environment)
   cmd.run_command
   Chef::Log.debug "rabbitmq_user_exists?: #{cmd}"
   Chef::Log.debug "rabbitmq_user_exists?: #{cmd.stdout}"
@@ -38,8 +37,7 @@ end
 
 def user_has_tag?(name, tag)
   cmd = 'rabbitmqctl -q list_users'
-  cmd = Mixlib::ShellOut.new(cmd)
-  cmd.environment = shell_environment
+  cmd = Mixlib::ShellOut.new(cmd, :env => shell_environment)
   cmd.run_command
   user_list = cmd.stdout
   tags = user_list.match(/^#{name}\s+\[(.*?)\]/)[1].split
@@ -62,8 +60,7 @@ end
 def user_has_permissions?(name, vhost, perm_list = nil)
   vhost = '/' if vhost.nil? # rubocop:enable all
   cmd = "rabbitmqctl -q list_user_permissions #{name} | grep \"^#{vhost}\\s\""
-  cmd = Mixlib::ShellOut.new(cmd)
-  cmd.environment = shell_environment
+  cmd = Mixlib::ShellOut.new(cmd, :env => shell_environment)
   cmd.run_command
   Chef::Log.debug "rabbitmq_user_has_permissions?: #{cmd}"
   Chef::Log.debug "rabbitmq_user_has_permissions?: #{cmd.stdout}"

--- a/providers/vhost.rb
+++ b/providers/vhost.rb
@@ -23,8 +23,7 @@ use_inline_resources
 
 def vhost_exists?(name)
   cmd = "rabbitmqctl -q list_vhosts | grep ^#{name}$"
-  cmd = Mixlib::ShellOut.new(cmd)
-  cmd.environment = shell_environment
+  cmd = Mixlib::ShellOut.new(cmd, :env => shell_environment)
   cmd.run_command
   Chef::Log.debug "rabbitmq_vhost_exists?: #{cmd}"
   Chef::Log.debug "rabbitmq_vhost_exists?: #{cmd.stdout}"


### PR DESCRIPTION
Since the `Mixlib::ShellOut` doesn't have a setter for the `environment` attribute, passing the environment via constructor should fix it.