### PR TITLE
Update bundler that comes with Travis' ruby 2.1.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 sudo: false
 
 language: ruby
+# Travis: Bundler that comes with Ruby 2.1.0 is too old (1.6.9)
+before_install: gem update bundler
 bundler_args: --without kitchen_vagrant
 rvm:
 - 2.1.0

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ require 'cookstyle'
 # Style tests. Rubocop and Foodcritic
 namespace :style do
   desc 'Run Ruby style checks'
-  RuboCop::RakeTask.new do |task|
+  RuboCop::RakeTask.new(:ruby) do |task|
     task.options << '--display-cop-names'
   end
 

--- a/providers/parameter.rb
+++ b/providers/parameter.rb
@@ -22,6 +22,8 @@ require 'shellwords'
 
 include Opscode::RabbitMQ
 
+use_inline_resources
+
 def parameter_exists?(vhost, name)
   cmd = 'rabbitmqctl list_parameters'
   cmd << " -p #{Shellwords.escape vhost}" unless vhost.nil?

--- a/providers/policy.rb
+++ b/providers/policy.rb
@@ -22,6 +22,8 @@ require 'shellwords'
 
 include Opscode::RabbitMQ
 
+use_inline_resources
+
 def policy_exists?(vhost, name)
   cmd = 'rabbitmqctl list_policies'
   cmd << " -p #{Shellwords.escape vhost}" unless vhost.nil?

--- a/providers/vhost.rb
+++ b/providers/vhost.rb
@@ -19,6 +19,8 @@
 
 include Opscode::RabbitMQ
 
+use_inline_resources
+
 def vhost_exists?(name)
   cmd = "rabbitmqctl -q list_vhosts | grep ^#{name}$"
   cmd = Mixlib::ShellOut.new(cmd)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -43,7 +43,6 @@ when 'debian'
   # socat is a package dependency of rabbitmq-server
   package 'socat'
 
-
   # => Prevent Debian systems from automatically starting RabbitMQ after dpkg install
   dpkg_autostart node['rabbitmq']['service_name'] do
     allow false


### PR DESCRIPTION
Looks like the rake tasks are failing due to a very old version of bundler (1.6.9):
`LoadError: cannot load such file -- bundler/inline`

`bundler/inline` was introduced in version `1.10.0`.