### PR TITLE
Remove sensitive flag from config template

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -171,7 +171,6 @@ template "#{node['rabbitmq']['config_root']}/rabbitmq-env.conf" do
 end
 
 template "#{node['rabbitmq']['config']}.config" do
-  sensitive true
   source 'rabbitmq.config.erb'
   cookbook node['rabbitmq']['config_template_cookbook']
   owner 'root'


### PR DESCRIPTION
Config contains no secrets and suppressing the template diff makes
debugging considerably harder.

Can anyone shine some light why 'sensitive' was introduced in the first place?